### PR TITLE
Add supplier summary Excel export page

### DIFF
--- a/assets/js/supplier-summary-export.js
+++ b/assets/js/supplier-summary-export.js
@@ -1,0 +1,97 @@
+(function() {
+  'use strict';
+
+  const exportButtons = document.querySelectorAll('[data-export-target]');
+
+  if (!exportButtons.length) {
+    return;
+  }
+
+  const sanitiseTableForExport = (table) => {
+    if (!table) {
+      return '';
+    }
+
+    const clone = table.cloneNode(true);
+
+    clone.querySelectorAll('[data-export-exclude]')
+      .forEach((element) => element.remove());
+
+    clone.querySelectorAll('button, .btn, .badge, .sr-only').forEach((element) => {
+      if (element.closest('th') || element.closest('td')) {
+        element.replaceWith(element.textContent.trim());
+      } else {
+        element.remove();
+      }
+    });
+
+    return clone.outerHTML;
+  };
+
+  const buildWorkbookHtml = (options) => {
+    const { mainTable, balanceTable, title } = options;
+    const sections = [];
+
+    if (title) {
+      const columnCount = mainTable && mainTable.tHead
+        ? mainTable.tHead.rows[mainTable.tHead.rows.length - 1].cells.length
+        : (mainTable && mainTable.rows[0] ? mainTable.rows[0].cells.length : 1);
+      sections.push(
+        `<table><thead><tr><th colspan="${columnCount}" style="text-align:left;font-weight:bold;">${title}</th></tr></thead></table>`
+      );
+    }
+
+    sections.push(sanitiseTableForExport(mainTable));
+
+    if (balanceTable) {
+      sections.push('<table><tbody><tr><td style="height:12px"></td></tr></tbody></table>');
+      sections.push(sanitiseTableForExport(balanceTable));
+    }
+
+    return `
+      <html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel">
+        <head>
+          <meta charset="UTF-8">
+        </head>
+        <body>
+          ${sections.join('\n')}
+        </body>
+      </html>
+    `;
+  };
+
+  const triggerDownload = (html, filename) => {
+    const blob = new Blob(['\ufeff' + html], { type: 'application/vnd.ms-excel' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename || 'supplier-summary.xls';
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  exportButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const mainSelector = button.getAttribute('data-export-target');
+      if (!mainSelector) {
+        return;
+      }
+
+      const mainTable = document.querySelector(mainSelector);
+      if (!mainTable) {
+        console.warn('Supplier summary export: Unable to find summary table using selector', mainSelector);
+        return;
+      }
+
+      const balanceSelector = button.getAttribute('data-balance-table');
+      const balanceTable = balanceSelector ? document.querySelector(balanceSelector) : null;
+      const filename = button.getAttribute('data-export-filename') || 'supplier-summary.xls';
+      const title = button.getAttribute('data-export-title') || '';
+
+      const workbookHtml = buildWorkbookHtml({ mainTable, balanceTable, title });
+      triggerDownload(workbookHtml, filename);
+    });
+  });
+})();

--- a/php_files/admin/suppliers/17/index.php
+++ b/php_files/admin/suppliers/17/index.php
@@ -1,0 +1,520 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Supplier Summary</title>
+    <!-- plugins:css -->
+    <link rel="stylesheet" href="../../../../assets/vendors/mdi/css/materialdesignicons.min.css">
+    <link rel="stylesheet" href="../../../../assets/vendors/css/vendor.bundle.base.css">
+    <!-- endinject -->
+    <!-- Layout styles -->
+    <link rel="stylesheet" href="../../../../assets/css/style.css">
+    <!-- End layout styles -->
+    <link rel="shortcut icon" href="../../../../assets/images/favicon.png" />
+  </head>
+  <body>
+    <div class="container-scroller">
+      <nav class="sidebar sidebar-offcanvas" id="sidebar">
+        <div class="sidebar-brand-wrapper d-none d-lg-flex align-items-center justify-content-center fixed-top">
+          <a class="sidebar-brand brand-logo" href="../../../../index.html"><img src="../../../../assets/images/logo.svg" alt="logo" /></a>
+          <a class="sidebar-brand brand-logo-mini" href="../../../../index.html"><img src="../../../../assets/images/logo-mini.svg" alt="logo" /></a>
+        </div>
+        <ul class="nav">
+          <li class="nav-item profile">
+            <div class="profile-desc">
+              <div class="profile-pic">
+                <div class="count-indicator">
+                  <img class="img-xs rounded-circle " src="../../../../assets/images/faces/face15.jpg" alt="">
+                  <span class="count bg-success"></span>
+                </div>
+                <div class="profile-name">
+                  <h5 class="mb-0 font-weight-normal">Lawrence Chege</h5>
+                  <span>Gold Member</span>
+                </div>
+              </div>
+              <a href="#" id="profile-dropdown" data-bs-toggle="dropdown"><i class="mdi mdi-dots-vertical"></i></a>
+              <div class="dropdown-menu dropdown-menu-right sidebar-dropdown preview-list" aria-labelledby="profile-dropdown">
+                <a href="#" class="dropdown-item preview-item">
+                  <div class="preview-thumbnail">
+                    <div class="preview-icon bg-dark rounded-circle">
+                      <i class="mdi mdi-settings text-primary"></i>
+                    </div>
+                  </div>
+                  <div class="preview-item-content">
+                    <p class="preview-subject ellipsis mb-1 text-small">Account settings</p>
+                  </div>
+                </a>
+                <div class="dropdown-divider"></div>
+                <a href="#" class="dropdown-item preview-item">
+                  <div class="preview-thumbnail">
+                    <div class="preview-icon bg-dark rounded-circle">
+                      <i class="mdi mdi-onepassword  text-info"></i>
+                    </div>
+                  </div>
+                  <div class="preview-item-content">
+                    <p class="preview-subject ellipsis mb-1 text-small">Change Password</p>
+                  </div>
+                </a>
+                <div class="dropdown-divider"></div>
+                <a href="#" class="dropdown-item preview-item">
+                  <div class="preview-thumbnail">
+                    <div class="preview-icon bg-dark rounded-circle">
+                      <i class="mdi mdi-calendar-today text-success"></i>
+                    </div>
+                  </div>
+                  <div class="preview-item-content">
+                    <p class="preview-subject ellipsis mb-1 text-small">To-do list</p>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </li>
+          <li class="nav-item nav-category">
+            <span class="nav-link">Navigation</span>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" href="../../../../index.html">
+              <span class="menu-icon">
+                <i class="mdi mdi-speedometer"></i>
+              </span>
+              <span class="menu-title">Dashboard</span>
+            </a>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" data-bs-toggle="collapse" href="#ui-basic" aria-expanded="false" aria-controls="ui-basic">
+              <span class="menu-icon">
+                <i class="mdi mdi-laptop"></i>
+              </span>
+              <span class="menu-title">Basic UI Elements</span>
+              <i class="menu-arrow"></i>
+            </a>
+            <div class="collapse" id="ui-basic">
+              <ul class="nav flex-column sub-menu">
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/ui-features/buttons.html">Buttons</a></li>
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/ui-features/dropdowns.html">Dropdowns</a></li>
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/ui-features/typography.html">Typography</a></li>
+              </ul>
+            </div>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" href="../../../../pages/forms/basic_elements.html">
+              <span class="menu-icon">
+                <i class="mdi mdi-playlist-play"></i>
+              </span>
+              <span class="menu-title">Form Elements</span>
+            </a>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" href="../../../../pages/tables/basic-table.html">
+              <span class="menu-icon">
+                <i class="mdi mdi-table-large"></i>
+              </span>
+              <span class="menu-title">Tables</span>
+            </a>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" href="../../../../pages/charts/chartjs.html">
+              <span class="menu-icon">
+                <i class="mdi mdi-chart-bar"></i>
+              </span>
+              <span class="menu-title">Charts</span>
+            </a>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" href="../../../../pages/icons/mdi.html">
+              <span class="menu-icon">
+                <i class="mdi mdi-contacts"></i>
+              </span>
+              <span class="menu-title">Icons</span>
+            </a>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" data-bs-toggle="collapse" href="#auth" aria-expanded="false" aria-controls="auth">
+              <span class="menu-icon">
+                <i class="mdi mdi-security"></i>
+              </span>
+              <span class="menu-title">User Pages</span>
+              <i class="menu-arrow"></i>
+            </a>
+            <div class="collapse" id="auth">
+              <ul class="nav flex-column sub-menu">
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/samples/blank-page.html"> Blank Page </a></li>
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/samples/error-404.html"> 404 </a></li>
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/samples/error-500.html"> 500 </a></li>
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/samples/login.html"> Login </a></li>
+                <li class="nav-item"> <a class="nav-link" href="../../../../pages/samples/register.html"> Register </a></li>
+              </ul>
+            </div>
+          </li>
+          <li class="nav-item menu-items">
+            <a class="nav-link" href="https://www.bootstrapdash.com/demo/corona-free/jquery/documentation/documentation.html">
+              <span class="menu-icon">
+                <i class="mdi mdi-file-document-box"></i>
+              </span>
+              <span class="menu-title">Documentation</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div class="container-fluid page-body-wrapper">
+        <nav class="navbar p-0 fixed-top d-flex flex-row">
+          <div class="navbar-brand-wrapper d-flex d-lg-none align-items-center justify-content-center">
+            <a class="navbar-brand brand-logo-mini" href="../../../../index.html"><img src="../../../../assets/images/logo-mini.svg" alt="logo" /></a>
+          </div>
+          <div class="navbar-menu-wrapper flex-grow d-flex align-items-stretch">
+            <button class="navbar-toggler navbar-toggler align-self-center" type="button" data-toggle="minimize">
+              <span class="mdi mdi-menu"></span>
+            </button>
+            <ul class="navbar-nav w-100">
+              <li class="nav-item w-100">
+                <form class="nav-link mt-2 mt-md-0 d-none d-lg-flex search">
+                  <input type="text" class="form-control" placeholder="Search suppliers">
+                </form>
+              </li>
+            </ul>
+            <ul class="navbar-nav navbar-nav-right">
+              <li class="nav-item dropdown d-none d-lg-block">
+                <a class="nav-link btn btn-success create-new-button" id="createbuttonDropdown" data-bs-toggle="dropdown" aria-expanded="false" href="#">+ Create New Project</a>
+                <div class="dropdown-menu dropdown-menu-right navbar-dropdown preview-list" aria-labelledby="createbuttonDropdown">
+                  <h6 class="p-3 mb-0">Projects</h6>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-file-outline text-primary"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject ellipsis mb-1">Software Development</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-web text-info"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject ellipsis mb-1">UI Development</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-layers text-danger"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject ellipsis mb-1">Software Testing</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <p class="p-3 mb-0 text-center">See all projects</p>
+                </div>
+              </li>
+              <li class="nav-item dropdown border-left">
+                <a class="nav-link count-indicator dropdown-toggle" id="notificationDropdown" href="#" data-bs-toggle="dropdown">
+                  <i class="mdi mdi-bell"></i>
+                  <span class="count bg-danger"></span>
+                </a>
+                <div class="dropdown-menu dropdown-menu-right navbar-dropdown preview-list" aria-labelledby="notificationDropdown">
+                  <h6 class="p-3 mb-0">Notifications</h6>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-calendar text-success"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject mb-1">Event today</p>
+                      <p class="text-muted ellipsis mb-0">Just a reminder that you have an event today</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-settings text-danger"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject mb-1">Settings</p>
+                      <p class="text-muted ellipsis mb-0">Update dashboard</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <p class="p-3 mb-0 text-center">See all notifications</p>
+                </div>
+              </li>
+              <li class="nav-item dropdown">
+                <a class="nav-link" id="profileDropdown" href="#" data-bs-toggle="dropdown">
+                  <div class="navbar-profile">
+                    <img class="img-xs rounded-circle" src="../../../../assets/images/faces/face15.jpg" alt="">
+                    <p class="mb-0 d-none d-sm-block navbar-profile-name">Lawrence Chege</p>
+                    <i class="mdi mdi-menu-down d-none d-sm-block"></i>
+                  </div>
+                </a>
+                <div class="dropdown-menu dropdown-menu-right navbar-dropdown preview-list" aria-labelledby="profileDropdown">
+                  <h6 class="p-3 mb-0">Profile</h6>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-settings text-success"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject mb-1">Settings</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item preview-item">
+                    <div class="preview-thumbnail">
+                      <div class="preview-icon bg-dark rounded-circle">
+                        <i class="mdi mdi-logout text-danger"></i>
+                      </div>
+                    </div>
+                    <div class="preview-item-content">
+                      <p class="preview-subject mb-1">Log out</p>
+                    </div>
+                  </a>
+                  <div class="dropdown-divider"></div>
+                  <p class="p-3 mb-0 text-center">Advanced settings</p>
+                </div>
+              </li>
+            </ul>
+            <button class="navbar-toggler navbar-toggler-right d-lg-none align-self-center" type="button" data-toggle="offcanvas">
+              <span class="mdi mdi-format-line-spacing"></span>
+            </button>
+          </div>
+        </nav>
+        <div class="main-panel">
+          <div class="content-wrapper">
+            <div class="row">
+              <div class="col-12 grid-margin">
+                <div class="card">
+                  <div class="card-body">
+                    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4 gap-3">
+                      <div>
+                        <h3 class="card-title mb-1">Supplier Summary</h3>
+                        <p class="text-muted mb-0">Supplier ID #17 · Updated 1 Sep 2025</p>
+                      </div>
+                    </div>
+                    <ul class="nav nav-tabs" id="supplierSummaryTabs" role="tablist">
+                      <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="summary-tab" data-bs-toggle="tab" data-bs-target="#supplier-summary" type="button" role="tab" aria-controls="supplier-summary" aria-selected="true">Summary</button>
+                      </li>
+                      <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#supplier-profile" type="button" role="tab" aria-controls="supplier-profile" aria-selected="false">Profile</button>
+                      </li>
+                    </ul>
+                    <div class="tab-content pt-4" id="supplierSummaryTabsContent">
+                      <div class="tab-pane fade show active" id="supplier-summary" role="tabpanel" aria-labelledby="summary-tab">
+                        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-3 gap-3">
+                          <div>
+                            <h5 class="fw-semibold mb-1">Delivery Transactions</h5>
+                            <p class="mb-0 text-muted">Vehicle drop-offs recorded for this supplier.</p>
+                          </div>
+                          <button class="btn btn-success" type="button" data-export-target="#supplierSummaryTable" data-balance-table="#supplierBalanceTable" data-export-filename="supplier-17-summary.xls" data-export-title="Supplier Summary Report">
+                            <i class="mdi mdi-file-excel me-2"></i>
+                            Export to Excel
+                          </button>
+                        </div>
+                        <div class="table-responsive">
+                          <table class="table table-hover" id="supplierSummaryTable">
+                            <thead class="table-light">
+                              <tr>
+                                <th>Vehicle Reg No</th>
+                                <th>Date</th>
+                                <th>Quantity</th>
+                                <th>Amount (after tax)</th>
+                                <th>Station</th>
+                                <th>Receipt No.</th>
+                                <th>Balance</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>KDH 369W</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>3,332.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,649,449.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KDC 369Y</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>3,332.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,646,117.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KDC 195U</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>3,332.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,642,785.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KDC 253A</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>3,332.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,639,453.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KDC 529X</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,597,803.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KCE 479P</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,556,153.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KCE 472J</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,514,503.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KCE 755K</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,472,853.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KCE 752J</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,431,203.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KMR 327S</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,389,553.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KDG 031W</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,347,903.00)</td>
+                              </tr>
+                              <tr>
+                                <td>KDG 831W</td>
+                                <td>01/09/2025</td>
+                                <td>20 litres</td>
+                                <td>41,650.00</td>
+                                <td>Astrol Mombasa Rd</td>
+                                <td>70639</td>
+                                <td>(2,306,253.00)</td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <div class="table-responsive mt-4">
+                          <table class="table table-bordered" id="supplierBalanceTable">
+                            <thead class="table-light">
+                              <tr>
+                                <th>Balance Entry</th>
+                                <th>Amount</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>Opening Balance</td>
+                                <td>(2,712,781.00)</td>
+                              </tr>
+                              <tr>
+                                <td>Total Deliveries</td>
+                                <td>498,300.00</td>
+                              </tr>
+                              <tr>
+                                <td>Payments Received</td>
+                                <td>(132,200.00)</td>
+                              </tr>
+                              <tr>
+                                <td>Current Balance</td>
+                                <td>(2,346,681.00)</td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                      <div class="tab-pane fade" id="supplier-profile" role="tabpanel" aria-labelledby="profile-tab">
+                        <div class="row">
+                          <div class="col-md-6">
+                            <h5 class="fw-semibold">Contact Details</h5>
+                            <p class="mb-2 text-muted">Astrol Fuel Supplies</p>
+                            <p class="mb-1">P.O. Box 12345-00100</p>
+                            <p class="mb-1">Nairobi, Kenya</p>
+                            <p class="mb-0">info@astrolfuels.co.ke · +254 700 000 000</p>
+                          </div>
+                          <div class="col-md-6">
+                            <h5 class="fw-semibold">Notes</h5>
+                            <p class="text-muted mb-0">Keep documents for September deliveries for reconciliation. Last audit completed on 29 Aug 2025.</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <footer class="footer">
+            <div class="d-sm-flex justify-content-center justify-content-sm-between">
+              <span class="text-muted d-block text-center text-sm-left d-sm-inline-block">Copyright © bootstrapdash.com 2021</span>
+              <span class="float-none float-sm-right d-block mt-1 mt-sm-0 text-center"> Free <a href="https://www.bootstrapdash.com/bootstrap-admin-template/" target="_blank">Bootstrap admin template</a> from Bootstrapdash.com</span>
+            </div>
+          </footer>
+        </div>
+      </div>
+    </div>
+    <script src="../../../../assets/vendors/js/vendor.bundle.base.js"></script>
+    <script src="../../../../assets/js/off-canvas.js"></script>
+    <script src="../../../../assets/js/hoverable-collapse.js"></script>
+    <script src="../../../../assets/js/misc.js"></script>
+    <script src="../../../../assets/js/settings.js"></script>
+    <script src="../../../../assets/js/todolist.js"></script>
+    <script src="../../../../assets/js/supplier-summary-export.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a supplier summary view under `php_files/admin/suppliers/17` with a summary tab, delivery table, and balance section
- wire an Export to Excel button that pulls both sections into a single workbook
- implement `assets/js/supplier-summary-export.js` to prepare the HTML workbook and trigger the download

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de820711588323839fddae082822c6